### PR TITLE
Symbols should always evaluate gt other datatypes.

### DIFF
--- a/test/test_linked_list_item.rb
+++ b/test/test_linked_list_item.rb
@@ -63,7 +63,7 @@ class LinkedListItemTest < NSS::TestCase
   end
 
   def test_05d_comparator_symbol
-    lli1 = LinkedListItem.new(:foo)
+    lli1 = LinkedListItem.new(:apple)
     lli2 = LinkedListItem.new("bar")
     assert lli1 > lli2
     assert lli2 < lli1


### PR DESCRIPTION
Test now clarifies the objective and requires additional code to the comparator.
